### PR TITLE
Strict check XMailer with empty string (#1764)

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -527,9 +527,9 @@ class PHPMailer
 
     /**
      * What to put in the X-Mailer header.
-     * Options: An empty string for PHPMailer default, whitespace for none, or a string to use.
+     * Options: An empty string for PHPMailer default, whitespace/null for none, or a string to use.
      *
-     * @var string
+     * @var string|null
      */
     public $XMailer = '';
 
@@ -2380,7 +2380,7 @@ class PHPMailer
         if (null !== $this->Priority) {
             $result .= $this->headerLine('X-Priority', $this->Priority);
         }
-        if ('' == $this->XMailer) {
+        if ('' === $this->XMailer) {
             $result .= $this->headerLine(
                 'X-Mailer',
                 'PHPMailer ' . self::VERSION . ' (https://github.com/PHPMailer/PHPMailer)'


### PR DESCRIPTION
Before submitting your pull request, check whether your code adheres to PHPMailer
coding standards by running the following command:

`./vendor/bin/php-cs-fixer --diff --dry-run --verbose fix `

And committing eventual changes. It's important that this command uses the specific version of php-cs-fixer configured for PHPMailer, so run `composer install` within the PHPMailer folder to use the exact version it needs.
